### PR TITLE
Zephyr 4.1 Port

### DIFF
--- a/lib/f_core/radio/c_lora.cpp
+++ b/lib/f_core/radio/c_lora.cpp
@@ -40,7 +40,7 @@ int CLora::ReceiveAsynchronous(const lora_recv_cb cb) {
         return ret;
     }
 
-    return lora_recv_async(lora_dev, cb);
+    return lora_recv_async(lora_dev, cb, nullptr);
 }
 
 inline int CLora::setTxRx(const Direction transmitDirection) {

--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.0.0
+      revision: v4.1.0
       import:
         name-allowlist:
           - cmsis


### PR DESCRIPTION
# Description
Zephyr 4.1 released a few hours ago. Not much change that impacts any of our codebase, besides bringing back the nullptr argument to lora_recv_async's user_data parameter we had a while back, before going back to a stable version of Zephyr. This update does bring along performance improvements that close the performance gap with other standard RTOSes though in many scenarios.

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Confirmed working compilation of all samples and applications through CI

# Checklist:
- [x] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [x] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [x] The CI checks are passing
- [x] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [x] I feel comfortable about this code flying in a rocket

