### PR TITLE
Decrease Power Module Logging Rate

### DIFF
--- a/app/backplane/power_module/include/c_sensing_tenant.h
+++ b/app/backplane/power_module/include/c_sensing_tenant.h
@@ -6,6 +6,7 @@
 #include <f_core/messaging/c_message_port.h>
 #include <f_core/os/c_tenant.h>
 #include <f_core/utils/c_observer.h>
+#include <f_core/utils/c_soft_timer.h>
 
 class CSensingTenant : public CTenant, public CObserver {
 public:
@@ -25,7 +26,7 @@ public:
 private:
     CMessagePort<NTypes::SensorData> &dataToBroadcast;
     CMessagePort<NTypes::SensorData> &dataToLog;
-    bool logData = false;
+    CSoftTimer timer{nullptr, nullptr};
 };
 
 

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -63,7 +63,6 @@ void CSensingTenant::Run() {
     dataToBroadcast.Send(data, K_MSEC(5));
 
     if (timer.IsExpired()) {
-        LOG_INF("Logged data");
         dataToLog.Send(data, K_MSEC(5));
     }
 }

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -8,6 +8,8 @@
 LOG_MODULE_REGISTER(CSensingTenant);
 
 void CSensingTenant::Startup() {
+    static constexpr uint32_t minuteInMillis = 1000 * 60;
+    timer.StartTimer(minuteInMillis); // Log every minute on the pad
 }
 
 void CSensingTenant::PostStartup() {
@@ -60,7 +62,8 @@ void CSensingTenant::Run() {
 
     dataToBroadcast.Send(data, K_MSEC(5));
 
-    if (logData) {
+    if (timer.IsExpired()) {
+        LOG_INF("Logged data");
         dataToLog.Send(data, K_MSEC(5));
     }
 }
@@ -70,12 +73,12 @@ void CSensingTenant::Notify(void *ctx) {
     switch (*static_cast<NAlerts::AlertType*>(ctx)) {
         case NAlerts::BOOST:
             LOG_INF("Boost detected. Logging data.");
-            logData = true;
+            timer.StartTimer(500); // Log every half a second during flight
             break;
 
         case NAlerts::LANDED:
             LOG_INF("Landing detected. Disabling logging.");
-            logData = false;
+            timer.StopTimer(); // Stop logging
             break;
 
         default:

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -9,7 +9,7 @@ LOG_MODULE_REGISTER(CSensingTenant);
 
 void CSensingTenant::Startup() {
     static constexpr uint32_t minuteInMillis = 1000 * 60;
-    timer.StartTimer(minuteInMillis); // Log every minute on the pad
+    timer.StartTimer(minuteInMillis, 0); // Log every minute on the pad
 }
 
 void CSensingTenant::PostStartup() {

--- a/app/backplane/power_module/src/main.cpp
+++ b/app/backplane/power_module/src/main.cpp
@@ -20,7 +20,7 @@ int main() {
     NRtos::StartRtos();
 
 #ifdef CONFIG_ARCH_POSIX
-    k_sleep(K_SECONDS(10));
+    k_sleep(K_SECONDS(300));
     NRtos::StopRtos();
     powerModule.Cleanup();
     k_sleep(K_FOREVER);

--- a/include/f_core/utils/c_soft_timer.h
+++ b/include/f_core/utils/c_soft_timer.h
@@ -32,6 +32,18 @@ public:
     }
 
     /**
+    * Start the timer with the given expiration time
+    * @param millis Time in milliseconds until the timer expires
+    * @param initialExpirationMillis Time in milliseconds to wait before the first expiration
+    */
+    void StartTimer(int millis, int initialExpirationMillis) {
+        // Duration (second arg) is the initial expiration time
+        // Period (third arg) is the time set after each expiration
+        k_timer_start(&timer, K_MSEC(initialExpirationMillis), K_MSEC(millis));
+        running = true;
+    }
+
+    /**
     * Stop the timer
     */
     void StopTimer() {


### PR DESCRIPTION
This closes #257

# Description
Slow down power module logging on the pad to one minute and half a second during flight. None during landing. This allows us to save space and not log unnecessarily since values will not change frequently

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Print out each time it logs and send alerts observing print rate.

<img width="475" alt="image" src="https://github.com/user-attachments/assets/46f515b6-c2cb-4741-aa71-18f89d42341b" />



# Checklist:
- [x] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [x] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [x] The CI checks are passing
- [x] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [x] I feel comfortable about this code flying in a rocket

