### PR TITLE
Git Statistics Ignore Generated Configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-**/.idea/* export-ignore
-data/orksim_csv/* export-ignore
-data/sim/* export-ignore
+**/.idea/* export-ignore linguist-generated=true
+data/orksim_csv/* export-ignore linguist-generated=true
+data/sim/* export-ignore linguist-generated=true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.idea/* export-ignore
+data/orksim_csv/* export-ignore
+data/sim/* export-ignore
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-.idea/* export-ignore
+**/.idea/* export-ignore
 data/orksim_csv/* export-ignore
 data/sim/* export-ignore
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,12 @@
-**/.idea/* export-ignore linguist-generated=true
-data/orksim_csv/* export-ignore linguist-generated=true
-data/sim/* export-ignore linguist-generated=true
+# Generated files
+**/.idea/* export-ignore linguist-generated=true -diff
+data/orksim_csv/* export-ignore linguist-generated=true -diff
+data/sim/* export-ignore linguist-generated=true -diff
 
+# Source Code
+*.c     text diff=cpp
+*.cpp   text diff=cpp
+*.hpp   text diff=cpp
+*.h     text diff=cpp
+*.py    text diff=python
+*.dts   text diff=devicetree

--- a/app/backplane/deployment_module/.idea/cmake.xml
+++ b/app/backplane/deployment_module/.idea/cmake.xml
@@ -8,3 +8,6 @@
     </configurations>
   </component>
 </project>
+
+
+

--- a/lib/f_core/net/application/c_tftp_server_tenant.cpp
+++ b/lib/f_core/net/application/c_tftp_server_tenant.cpp
@@ -9,8 +9,7 @@
 
 LOG_MODULE_REGISTER(CTftpServerTenant);
 
-char *inet_ntoa(struct in_addr in)
-{
+char *inet_ntoa(struct in_addr in) {
     static char buf[INET_ADDRSTRLEN];
     unsigned char *bytes = (unsigned char *)&in.s_addr;
 


### PR DESCRIPTION
Attempted to try and hide autogenerated file changes in GitHub, so PRs look less scary when reviewing. Doesn't actually hide it from diff during PRs and it still includes those changes as part of additions and deletions unfortunately. However, it does improve git CLI usage at the very least when trying to look at diffs (also added some language specific diff drivers). 

See https://git-scm.com/book/ms/v2/Customizing-Git-Git-Attributes for more information on git attributes.

Instead of GitHub saying the file is hiding the diff by default because its too big, it'll hide it because it was marked as generated though.
<img width="896" alt="image" src="https://github.com/user-attachments/assets/6f16e2b8-bc32-495d-a28f-f0c42ac613f3" />

Also, yes I know you shouldn't add editor files to a git repo, but this is different. In CLion (and I'm sure VSCode as well), you can have configurations for building the project, flashing and debugging through the IDE which means when you open the project in the IDE, the run configurations will already be there. This makes it nice for new developers getting started, working across different machines, etc.
