### PR TITLE
Power Module Battery Rail Sensing Fix

### DIFF
--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -12,8 +12,7 @@ void CSensingTenant::Startup() {
     timer.StartTimer(minuteInMillis, 0); // Log every minute on the pad
 }
 
-void CSensingTenant::PostStartup() {
-}
+void CSensingTenant::PostStartup() {}
 
 void CSensingTenant::Run() {
     NTypes::SensorData data{
@@ -38,12 +37,12 @@ void CSensingTenant::Run() {
     CShunt shuntBatt(*DEVICE_DT_GET(DT_ALIAS(shunt_batt)));
     CShunt shunt3v3(*DEVICE_DT_GET(DT_ALIAS(shunt_3v3)));
     CShunt shunt5v0(*DEVICE_DT_GET(DT_ALIAS(shunt_5v0)));
-    CSensorDevice *sensors[] = {&shuntBatt, &shunt3v3, &shunt5v0};
+    CSensorDevice* sensors[] = {&shuntBatt, &shunt3v3, &shunt5v0};
 #endif
 
 #ifndef CONFIG_ARCH_POSIX
-    int i =0;
-    for (auto sensor: sensors) {
+    int i = 0;
+    for (auto sensor : sensors) {
         if (!sensor->UpdateSensorValue()) {
             LOG_ERR("Failed to update sensor value for %d", i);
         }
@@ -70,7 +69,7 @@ void CSensingTenant::Run() {
     }
 }
 
-void CSensingTenant::Notify(void *ctx) {
+void CSensingTenant::Notify(void* ctx) {
     // TODO: Knock, knock! Race condition...
     switch (*static_cast<NAlerts::AlertType*>(ctx)) {
         case NAlerts::BOOST:


### PR DESCRIPTION
# Description
Copypasta error was done where we read the 5V rail twice instead of also reading the battery rail

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Ran a power drain test on the entire backplane with it reporting legitimate values

# Checklist:

- [x] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [x] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [x] The CI checks are passing
- [x] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [x] I feel comfortable about this code flying in a rocket

