### PR TITLE
Calibrate Power Module Shunts

### DIFF
--- a/app/backplane/power_module/include/c_power_module.h
+++ b/app/backplane/power_module/include/c_power_module.h
@@ -61,9 +61,12 @@ private:
     CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{"Data Logger Tenant", "/lfs/sensor_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort};
     CUdpAlertTenant alertTenant{"Alert Tenant", ipAddrStr, NNetworkDefs::ALERT_PORT};
 
+
     // Tasks
+    static constexpr int ina219SampleTimeMillis = 69; // 68.1 ms based on our devicetree configuration, and we don't need to sample that quickly
+
     CTask networkTask{"Networking Task", 15, 3072, 0};
-    CTask sensingTask{"Sensing Task", 15, 1024, 0};
+    CTask sensingTask{"Sensing Task", 15, 1024, ina219SampleTimeMillis};
     CTask dataLoggingTask{"Data Logging Task", 15, 1500, 0};
 };
 

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -49,7 +49,11 @@ void CSensingTenant::Run() {
         i++;
     }
 
-    data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT);
+    static constexpr float extra3VCalibrationDivisor = 1.128f;
+    static constexpr float starting3VCurrentOffset = 0.20867f; // Power Module is a black box. Factor it out. We could not have LEDs on for example.
+    // data.Rail3v3.Current = (shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) - starting3VCurrentOffset) / extra3VCalibrationDivisor;
+    static constexpr float extra3VCalibrationFactor = 1.13f;
+    data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extra3VCalibrationFactor;
     data.Rail3v3.Voltage = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail3v3.Power = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_POWER);
 

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -49,9 +49,10 @@ void CSensingTenant::Run() {
         i++;
     }
 
-    static constexpr float extra3VCalibrationDivisor = 1.128f;
-    static constexpr float starting3VCurrentOffset = 0.20867f; // Power Module is a black box. Factor it out. We could not have LEDs on for example.
-    // data.Rail3v3.Current = (shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) - starting3VCurrentOffset) / extra3VCalibrationDivisor;
+    // NOTE: The below calibration values were determined based on using a load tester
+    // Zephyr does not support inputting floats into the LSB microamp offset, so we must do it manually
+
+    // Power Module is a black box. Factor it out. We could not have LEDs on for example.
     static constexpr float extra3VCalibrationFactor = 1.13f;
     data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extra3VCalibrationFactor;
     data.Rail3v3.Voltage = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
@@ -62,7 +63,8 @@ void CSensingTenant::Run() {
     data.Rail5v0.Voltage = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail5v0.Power = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_POWER);
 
-    data.RailBattery.Current = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_CURRENT);
+    static constexpr float extraBattCalibrationDivisor = 1.04f;
+    data.RailBattery.Current = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extraBattCalibrationDivisor;
     data.RailBattery.Voltage = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.RailBattery.Power = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_POWER);
 #endif

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -51,8 +51,6 @@ void CSensingTenant::Run() {
 
     // NOTE: The below calibration values were determined based on using a load tester
     // Zephyr does not support inputting floats into the LSB microamp offset, so we must do it manually
-
-    // Power Module is a black box. Factor it out. We could not have LEDs on for example.
     static constexpr float extra3VCalibrationDivisor = 1.13f;
     data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extra3VCalibrationDivisor;
     data.Rail3v3.Voltage = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -53,7 +53,8 @@ void CSensingTenant::Run() {
     data.Rail3v3.Voltage = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail3v3.Power = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_POWER);
 
-    data.Rail5v0.Current = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_CURRENT);
+    static constexpr float extra5VCalibration = 0.98f;
+    data.Rail5v0.Current = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extra5VCalibration;
     data.Rail5v0.Voltage = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail5v0.Power = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_POWER);
 

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -51,18 +51,19 @@ void CSensingTenant::Run() {
 
     // NOTE: The below calibration values were determined based on using a load tester
     // Zephyr does not support inputting floats into the LSB microamp offset, so we must do it manually
-    static constexpr float extra3VCalibrationDivisor = 1.13f;
-    data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extra3VCalibrationDivisor;
+    static constexpr float extra3VCalibrationMultiplier = 0.885f;
+    data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extra3VCalibrationMultiplier;
     data.Rail3v3.Voltage = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail3v3.Power = data.Rail3v3.Current * data.Rail3v3.Voltage;
 
-    static constexpr float extra5VCalibrationFactor = 0.98f;
-    data.Rail5v0.Current = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extra5VCalibrationFactor;
+    static constexpr float extra5VCalibrationMultiplier = 0.980f;
+    data.Rail5v0.Current = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extra5VCalibrationMultiplier;
+
     data.Rail5v0.Voltage = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail5v0.Power = data.Rail5v0.Current * data.Rail5v0.Voltage;
 
-    static constexpr float extraBattCalibrationDivisor = 1.04f;
-    data.RailBattery.Current = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extraBattCalibrationDivisor;
+    static constexpr float extraBattCalibrationMultiplier = 0.962f;
+    data.RailBattery.Current = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extraBattCalibrationMultiplier;
     data.RailBattery.Voltage = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.RailBattery.Power = data.RailBattery.Current * data.RailBattery.Voltage;
 #endif

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -53,13 +53,13 @@ void CSensingTenant::Run() {
     // Zephyr does not support inputting floats into the LSB microamp offset, so we must do it manually
 
     // Power Module is a black box. Factor it out. We could not have LEDs on for example.
-    static constexpr float extra3VCalibrationFactor = 1.13f;
-    data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extra3VCalibrationFactor;
+    static constexpr float extra3VCalibrationDivisor = 1.13f;
+    data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extra3VCalibrationDivisor;
     data.Rail3v3.Voltage = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail3v3.Power = data.Rail3v3.Current * data.Rail3v3.Voltage;
 
-    static constexpr float extra5VCalibration = 0.98f;
-    data.Rail5v0.Current = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extra5VCalibration;
+    static constexpr float extra5VCalibrationFactor = 0.98f;
+    data.Rail5v0.Current = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extra5VCalibrationFactor;
     data.Rail5v0.Voltage = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
     data.Rail5v0.Power = data.Rail5v0.Current * data.Rail5v0.Voltage;
 

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -56,17 +56,17 @@ void CSensingTenant::Run() {
     static constexpr float extra3VCalibrationFactor = 1.13f;
     data.Rail3v3.Current = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extra3VCalibrationFactor;
     data.Rail3v3.Voltage = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
-    data.Rail3v3.Power = shunt3v3.GetSensorValueFloat(SENSOR_CHAN_POWER);
+    data.Rail3v3.Power = data.Rail3v3.Current * data.Rail3v3.Voltage;
 
     static constexpr float extra5VCalibration = 0.98f;
     data.Rail5v0.Current = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_CURRENT) * extra5VCalibration;
     data.Rail5v0.Voltage = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
-    data.Rail5v0.Power = shunt5v0.GetSensorValueFloat(SENSOR_CHAN_POWER);
+    data.Rail5v0.Power = data.Rail5v0.Current * data.Rail5v0.Voltage;
 
     static constexpr float extraBattCalibrationDivisor = 1.04f;
     data.RailBattery.Current = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_CURRENT) / extraBattCalibrationDivisor;
     data.RailBattery.Voltage = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_VOLTAGE);
-    data.RailBattery.Power = shuntBatt.GetSensorValueFloat(SENSOR_CHAN_POWER);
+    data.RailBattery.Power = data.RailBattery.Current * data.RailBattery.Voltage;
 #endif
 
     dataToBroadcast.Send(data, K_MSEC(5));

--- a/app/backplane/radio_module/.run/JLink.run.xml
+++ b/app/backplane/radio_module/.run/JLink.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="JLink" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-if SWD -device STM32F446RE" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="power-module" TARGET_NAME="zephyr" CONFIG_NAME="Flight Release" version="1" RUN_TARGET_PROJECT_NAME="power-module" RUN_TARGET_NAME="zephyr_final">
+  <configuration default="false" name="JLink" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-if SWD -device STM32F446RE" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="receiver-module" TARGET_NAME="zephyr_final" CONFIG_NAME="Debug" version="1" RUN_TARGET_PROJECT_NAME="receiver-module" RUN_TARGET_NAME="zephyr_final">
     <custom-gdb-server version="1" gdb-connect="tcp:localhost:2331" executable="/usr/bin/JLinkGDBServer" warmup-ms="0" download-type="UPDATED_ONLY" reset-cmd="monitor reset" reset-type="AFTER_DOWNLOAD">
       <debugger kind="GDB" isBundled="true" />
     </custom-gdb-server>

--- a/app/backplane/radio_module/.run/JLink.run.xml
+++ b/app/backplane/radio_module/.run/JLink.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="JLink" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-if SWD -device STM32F446RE" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="receiver-module" TARGET_NAME="zephyr_final" CONFIG_NAME="Debug" version="1" RUN_TARGET_PROJECT_NAME="receiver-module" RUN_TARGET_NAME="zephyr_final">
+  <configuration default="false" name="JLink" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-if SWD -device STM32F446RE" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="radio-module" TARGET_NAME="zephyr_final" CONFIG_NAME="Flight Debug" version="1" RUN_TARGET_PROJECT_NAME="radio-module" RUN_TARGET_NAME="zephyr_final">
     <custom-gdb-server version="1" gdb-connect="tcp:localhost:2331" executable="/usr/bin/JLinkGDBServer" warmup-ms="0" download-type="UPDATED_ONLY" reset-cmd="monitor reset" reset-type="AFTER_DOWNLOAD">
       <debugger kind="GDB" isBundled="true" />
     </custom-gdb-server>

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -110,11 +110,11 @@
         compatible = "ti,ina219";
         reg = <0x40>;
         brng = <0>; // Set to 0 since we don't expect >16V
-        pg = <1>;
+        pg = <0>; // 7.5 mV drop.
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <300>;
+        lsb-microamp = <400>;
     };
 
     ina1: ina219_3v3@44 {
@@ -122,7 +122,7 @@
         compatible = "ti,ina219";
         reg = <0x44>;
         brng = <0>; // Set to 0 since we don't expect >16V
-        pg = <0>;
+        pg = <0>; // 5.0 mV drop
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
@@ -134,11 +134,11 @@
         compatible = "ti,ina219";
         reg = <0x41>;
         brng = <0>; // Set to 0 since we don't expect >16V
-        pg = <0>;
+        pg = <0>; // 0 mV drop
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <10>;
+        lsb-microamp = <33>;
     };
 };
 

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -110,11 +110,11 @@
         compatible = "ti,ina219";
         reg = <0x40>;
         brng = <0>; // Set to 0 since we don't expect >16V
-        pg = <3>;
+        pg = <1>;
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <2000>;
+        lsb-microamp = <300>;
     };
 
     ina1: ina219_3v3@44 {
@@ -126,7 +126,7 @@
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <60>;
+        lsb-microamp = <5>;
     };
 
     ina2: ina219_5v0@41 {
@@ -138,7 +138,7 @@
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <150>;
+        lsb-microamp = <10>;
     };
 };
 

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -122,11 +122,11 @@
         compatible = "ti,ina219";
         reg = <0x44>;
         brng = <0>; // Set to 0 since we don't expect >16V
-        pg = <0>; // 5.0 mV drop
+        pg = <0>; // 0 mV drop
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <5>;
+        lsb-microamp = <33>;
     };
 
     ina2: ina219_5v0@41 {

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -109,11 +109,11 @@
         status = "okay";
         compatible = "ti,ina219";
         reg = <0x40>;
-        brng = <0>;
+        brng = <0>; // Set to 0 since we don't expect >16V
         pg = <0>;
-        sadc = <13>;
-        badc = <13>;
-        shunt-milliohm = <100>;
+        sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
+        badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
+        shunt-milliohm = <5>;
         lsb-microamp = <10>;
     };
 
@@ -121,11 +121,11 @@
         status = "okay";
         compatible = "ti,ina219";
         reg = <0x44>;
-        brng = <0>;
+        brng = <0>; // Set to 0 since we don't expect >16V
         pg = <0>;
-        sadc = <13>;
-        badc = <13>;
-        shunt-milliohm = <100>;
+        sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
+        badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
+        shunt-milliohm = <5>;
         lsb-microamp = <10>;
     };
 
@@ -133,11 +133,11 @@
         status = "okay";
         compatible = "ti,ina219";
         reg = <0x41>;
-        brng = <0>;
+        brng = <0>; // Set to 0 since we don't expect >16V
         pg = <0>;
-        sadc = <13>;
-        badc = <13>;
-        shunt-milliohm = <100>;
+        sadc = <13>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
+        badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
+        shunt-milliohm = <5>;
         lsb-microamp = <10>;
     };
 };

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -110,11 +110,11 @@
         compatible = "ti,ina219";
         reg = <0x40>;
         brng = <0>; // Set to 0 since we don't expect >16V
-        pg = <0>;
+        pg = <3>;
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <10>;
+        lsb-microamp = <2000>;
     };
 
     ina1: ina219_3v3@44 {
@@ -126,7 +126,7 @@
         sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <10>;
+        lsb-microamp = <60>;
     };
 
     ina2: ina219_5v0@41 {
@@ -135,10 +135,10 @@
         reg = <0x41>;
         brng = <0>; // Set to 0 since we don't expect >16V
         pg = <0>;
-        sadc = <13>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
+        sadc = <15>; // Shunt ADC: 12 bit - 128 sample averaging - 68.10 ms
         badc = <15>; // Bus ADC: 12 bit - 128 sample averaging - 68.10 ms
         shunt-milliohm = <5>;
-        lsb-microamp = <10>;
+        lsb-microamp = <150>;
     };
 };
 

--- a/boards/arm/power_module/power_module_2.overlay
+++ b/boards/arm/power_module/power_module_2.overlay
@@ -28,7 +28,7 @@
         };
 
         wiznet_led: wiznet_led {
-            gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
+            gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
         };
 
 	};

--- a/boards/arm/power_module/power_module_2.overlay
+++ b/boards/arm/power_module/power_module_2.overlay
@@ -28,7 +28,7 @@
         };
 
         wiznet_led: wiznet_led {
-            gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
+            gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
         };
 
 	};


### PR DESCRIPTION
# Description
The INA219s need to be calibrated to report the correct values for power and current. Since Zephyr's devicetree doesn't allow us to do floats, we need to do extra math in software to calculate the true current. Since current is post-processed, we have to derive power from multiplying the voltage and software calibrated current

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Used a load tester to determine the values they were offset by and compare to the power module readings. Tested on three different power modules and they measured close to each other. The original calibrated power module (2) was ~0-2mA difference. The other power modules were ~1-5mA difference (depending on the current. Less than 100 mA and greater than 600 mA there is a little more drift)

# Checklist:

- [x] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [x] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [x] The CI checks are passing
- [x] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [x] I feel comfortable about this code flying in a rocket

