### PR TITLE
Decrease LoRa Packet Sizes

### DIFF
--- a/app/backplane/power_module/ac/types.yaml
+++ b/app/backplane/power_module/ac/types.yaml
@@ -8,3 +8,12 @@ SensorData:
     - name: Rail5v0
       type: ShuntData
   timestamp: true
+
+LoRaBroadcastSensorData:
+  description: Power Module Grouped Shunt Sensor Data to be sent over LoRa.
+  fields:
+    - name: RailBattery
+      type: FixedPointShuntData
+    - name: Rail3v3
+      type: FixedPointShuntData
+  timestamp: false

--- a/app/backplane/power_module/include/c_power_module.h
+++ b/app/backplane/power_module/include/c_power_module.h
@@ -45,7 +45,8 @@ public:
 
 private:
     const char* ipAddrStr = (CREATE_IP_ADDR(NNetworkDefs::POWER_MODULE_IP_ADDR_BASE, 2, CONFIG_MODULE_ID)).c_str();
-    const char* sntpServerAddr = "10.2.1.1"; // TODO: Maybe we should look into hostnames? Also, still need to fix the create ip addr bug...
+    const char* sntpServerAddr = "10.2.1.1";
+    // TODO: Maybe we should look into hostnames? Also, still need to fix the create ip addr bug...
     static constexpr int telemetryBroadcastPort = NNetworkDefs::POWER_MODULE_INA_DATA_PORT;
 
     // Devices
@@ -54,11 +55,18 @@ private:
     // Message Ports
     CMessagePort<NTypes::SensorData>& sensorDataBroadcastMessagePort;
     CMessagePort<NTypes::SensorData>& sensorDataLogMessagePort;
+    CMessagePort<NTypes::LoRaBroadcastSensorData>& sensorDataDownlinkMessagePort;
 
     // Tenants
-    CSensingTenant sensingTenant{"Sensing Tenant", sensorDataBroadcastMessagePort, sensorDataLogMessagePort};
-    CUdpBroadcastTenant<NTypes::SensorData> broadcastTenant{"Broadcast Tenant", ipAddrStr, telemetryBroadcastPort, telemetryBroadcastPort, sensorDataBroadcastMessagePort};
-    CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{"Data Logger Tenant", "/lfs/sensor_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort};
+    CSensingTenant sensingTenant{
+        "Sensing Tenant", sensorDataBroadcastMessagePort, sensorDataLogMessagePort, sensorDataDownlinkMessagePort
+    };
+    CUdpBroadcastTenant<NTypes::SensorData> broadcastTenant{
+        "Broadcast Tenant", ipAddrStr, telemetryBroadcastPort, telemetryBroadcastPort, sensorDataBroadcastMessagePort
+    };
+    CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{
+        "Data Logger Tenant", "/lfs/sensor_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort
+    };
     CUdpAlertTenant alertTenant{"Alert Tenant", ipAddrStr, NNetworkDefs::ALERT_PORT};
 
     // Tasks
@@ -66,7 +74,6 @@ private:
     CTask sensingTask{"Sensing Task", 15, 1024, 0};
     CTask dataLoggingTask{"Data Logging Task", 15, 1500, 0};
 };
-
 
 
 #endif //C_SENSOR_MODULE_H

--- a/app/backplane/power_module/include/c_sensing_tenant.h
+++ b/app/backplane/power_module/include/c_sensing_tenant.h
@@ -10,8 +10,8 @@
 
 class CSensingTenant : public CTenant, public CObserver {
 public:
-    explicit CSensingTenant(const char* name, CMessagePort<NTypes::SensorData> &dataToBroadcast, CMessagePort<NTypes::SensorData> &dataToLog)
-        : CTenant(name), dataToBroadcast(dataToBroadcast), dataToLog(dataToLog) {}
+    explicit CSensingTenant(const char* name, CMessagePort<NTypes::SensorData> &dataToBroadcast, CMessagePort<NTypes::SensorData> &dataToLog, CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink)
+        : CTenant(name), dataToBroadcast(dataToBroadcast), dataToLog(dataToLog), dataToDownlink(dataToDownlink) {}
 
     ~CSensingTenant() override = default;
 
@@ -26,6 +26,7 @@ public:
 private:
     CMessagePort<NTypes::SensorData> &dataToBroadcast;
     CMessagePort<NTypes::SensorData> &dataToLog;
+    CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink;
     CSoftTimer timer{nullptr, nullptr};
 };
 

--- a/app/backplane/power_module/include/c_sensing_tenant.h
+++ b/app/backplane/power_module/include/c_sensing_tenant.h
@@ -28,6 +28,8 @@ private:
     CMessagePort<NTypes::SensorData> &dataToLog;
     CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink;
     CSoftTimer timer{nullptr, nullptr};
+
+    void sendDownlinkData(const NTypes::SensorData &data);
 };
 
 

--- a/app/backplane/power_module/src/c_power_module.cpp
+++ b/app/backplane/power_module/src/c_power_module.cpp
@@ -13,7 +13,12 @@ static auto broadcastMsgQueue = CMsgqMessagePort<NTypes::SensorData>(broadcastQu
 K_MSGQ_DEFINE(dataLogQueue, sizeof(NTypes::SensorData), 10, 4);
 static auto dataLogMsgQueue = CMsgqMessagePort<NTypes::SensorData>(dataLogQueue);
 
-CPowerModule::CPowerModule() : CProjectConfiguration(), sensorDataBroadcastMessagePort(broadcastMsgQueue), sensorDataLogMessagePort(dataLogMsgQueue) {}
+K_MSGQ_DEFINE(downlinkQueue, sizeof(NTypes::LoRaBroadcastSensorData), 10, 4);
+static auto downlinkMessageQueue = CMsgqMessagePort<NTypes::LoRaBroadcastSensorData>(downlinkQueue);
+
+CPowerModule::CPowerModule() : CProjectConfiguration(), sensorDataBroadcastMessagePort(broadcastMsgQueue),
+                               sensorDataLogMessagePort(dataLogMsgQueue),
+                               sensorDataDownlinkMessagePort(downlinkMessageQueue) {}
 
 void CPowerModule::AddTenantsToTasks() {
     // Networking

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -63,6 +63,7 @@ void CSensingTenant::Run() {
 #endif
 
     dataToBroadcast.Send(data, K_MSEC(5));
+    sendDownlinkData(data);
 
     if (timer.IsExpired()) {
         dataToLog.Send(data, K_MSEC(5));
@@ -85,4 +86,21 @@ void CSensingTenant::Notify(void* ctx) {
         default:
             return;
     }
+}
+
+void CSensingTenant::sendDownlinkData(const NTypes::SensorData& data) {
+    NTypes::LoRaBroadcastSensorData downlinkData{
+        .RailBattery = {
+            .Voltage = static_cast<int16_t>(data.RailBattery.Voltage),
+            .Current = static_cast<int16_t>(data.RailBattery.Current),
+            .Power = static_cast<int16_t>(data.RailBattery.Power)
+        },
+        .Rail3v3 = {
+            .Voltage = static_cast<int16_t>(data.Rail3v3.Voltage),
+            .Current = static_cast<int16_t>(data.Rail3v3.Current),
+            .Power = static_cast<int16_t>(data.Rail3v3.Power)
+        }
+    };
+
+    dataToDownlink.Send(downlinkData, K_MSEC(5));
 }

--- a/app/backplane/radio_module/.run/JLink.run.xml
+++ b/app/backplane/radio_module/.run/JLink.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="JLink" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-if SWD -device STM32F446RE" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="radio-module" TARGET_NAME="zephyr_final" CONFIG_NAME="Flight Debug" version="1" RUN_TARGET_PROJECT_NAME="radio-module" RUN_TARGET_NAME="zephyr_final">
+  <configuration default="false" name="JLink" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-if SWD -device STM32F446RE" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="sensor-module" TARGET_NAME="zephyr_final" CONFIG_NAME="Flight Release" version="1" RUN_TARGET_PROJECT_NAME="sensor-module" RUN_TARGET_NAME="zephyr_final">
     <custom-gdb-server version="1" gdb-connect="tcp:localhost:2331" executable="/usr/bin/JLinkGDBServer" warmup-ms="0" download-type="UPDATED_ONLY" reset-cmd="monitor reset" reset-type="AFTER_DOWNLOAD">
       <debugger kind="GDB" isBundled="true" />
     </custom-gdb-server>

--- a/app/backplane/sensor_module/ac/types.yaml
+++ b/app/backplane/sensor_module/ac/types.yaml
@@ -24,6 +24,6 @@ LoRaBroadcastSensorData:
       type: FixedPointBarometerData
     - name: Acceleration
       type: FixedPointAccelerometerData
-    - name: ImuGyroscope
-      type: GyroscopeData
+    - name: Gyroscope
+      type: FixedPointGyroscopeData
   timestamp: false

--- a/app/backplane/sensor_module/ac/types.yaml
+++ b/app/backplane/sensor_module/ac/types.yaml
@@ -26,4 +26,4 @@ LoRaBroadcastSensorData:
       type: FixedPointAccelerometerData
     - name: ImuGyroscope
       type: GyroscopeData
-  timestamp: true
+  timestamp: false

--- a/app/backplane/sensor_module/ac/types.yaml
+++ b/app/backplane/sensor_module/ac/types.yaml
@@ -16,3 +16,14 @@ SensorData:
     - name: Temperature
       type: TemperatureData
   timestamp: true
+
+LoRaBroadcastSensorData:
+  description: Sensor Module LoRa Broadcast Sensor Data
+  fields:
+    - name: Barometer
+      type: FixedPointBarometerData
+    - name: Acceleration
+      type: FixedPointAccelerometerData
+    - name: ImuGyroscope
+      type: GyroscopeData
+  timestamp: true

--- a/app/backplane/sensor_module/include/c_detection_handler.h
+++ b/app/backplane/sensor_module/include/c_detection_handler.h
@@ -72,6 +72,10 @@ class CDetectionHandler {
      */
     void HandleGround(const uint32_t t_plus_ms, const NTypes::SensorData &data, const SensorWorkings &workings);
 
+    bool FlightOccurring() {
+        return controller.HasEventOccured(Events::Boost) && !controller.HasEventOccured(Events::GroundHit);
+    }
+
     /**
      * Whether or not the phase detector needs more data. True before ground hit, false after
      * @return true if the detection system wants more data, false if we're all finished

--- a/app/backplane/sensor_module/include/c_sensing_tenant.h
+++ b/app/backplane/sensor_module/include/c_sensing_tenant.h
@@ -29,6 +29,7 @@ class CSensingTenant : public CTenant {
   private:
     CMessagePort<NTypes::SensorData> &dataToBroadcast;
     CMessagePort<NTypes::SensorData> &dataToLog;
+    CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink;
 
     CDetectionHandler &detectionHandler;
     // Sensor instances

--- a/app/backplane/sensor_module/include/c_sensing_tenant.h
+++ b/app/backplane/sensor_module/include/c_sensing_tenant.h
@@ -18,7 +18,7 @@ class CSensorDevice;
 
 class CSensingTenant : public CTenant {
   public:
-    explicit CSensingTenant(const char *name, CMessagePort<NTypes::SensorData> &dataToBroadcast,
+    explicit CSensingTenant(const char *name, CMessagePort<NTypes::SensorData> &dataToBroadcast, CMessagePort<NTypes::LoRaBroadcastSensorData> &downlinkDataToBroadcast,
                             CMessagePort<NTypes::SensorData> &dataToLog, CDetectionHandler &handler);
     ~CSensingTenant() override = default;
 
@@ -41,6 +41,8 @@ class CSensingTenant : public CTenant {
     CMagnetometer magnetometer;
 
     std::array<CSensorDevice *, 7> sensors;
+
+    void sendDownlinkData(const NTypes::SensorData &data);
 };
 
 #endif // C_SENSING_TENANT_H

--- a/app/backplane/sensor_module/include/c_sensor_module.h
+++ b/app/backplane/sensor_module/include/c_sensor_module.h
@@ -5,6 +5,8 @@
 #include "flight.hpp"
 
 // F-Core Includes
+#include "../build-flight-release/zephyr/include/generated/FSW/n_autocoder_types.h"
+
 #include <f_core/c_project_configuration.h>
 #include <f_core/messaging/c_message_port.h>
 #include <f_core/n_alerts.h>
@@ -50,6 +52,7 @@ class CSensorModule : public CProjectConfiguration {
     const char* sntpServerAddr = "10.2.1.1"; // TODO: Maybe we should look into hostnames? Also, still need to fix the create ip addr bug...
 
     static constexpr int telemetryBroadcastPort = NNetworkDefs::SENSOR_MODULE_TELEMETRY_PORT;
+    static constexpr int telemetryDownlinkPort = NNetworkDefs::SENSOR_MODULE_DOWNLINK_DATA_PORT;
     static constexpr int alertPort = NNetworkDefs::ALERT_PORT;
 
     // Devices
@@ -57,6 +60,7 @@ class CSensorModule : public CProjectConfiguration {
 
     // Message Ports
     CMessagePort<NTypes::SensorData>& sensorDataBroadcastMessagePort;
+    CMessagePort<NTypes::LoRaBroadcastSensorData>& downlinkMessagePort;
     CMessagePort<NTypes::SensorData>& sensorDataLogMessagePort;
     CMessagePort<std::array<uint8_t, 7>>& alertMessagePort;
 
@@ -65,9 +69,10 @@ class CSensorModule : public CProjectConfiguration {
     CDetectionHandler detectionHandler{controller, alertMessagePort};
 
     // Tenants
-    CSensingTenant sensingTenant{"Sensing Tenant", sensorDataBroadcastMessagePort, sensorDataLogMessagePort,
+    CSensingTenant sensingTenant{"Sensing Tenant", sensorDataBroadcastMessagePort, downlinkMessagePort, sensorDataLogMessagePort,
                              detectionHandler};
     CUdpBroadcastTenant<NTypes::SensorData> broadcastTenant{"Broadcast Tenant", ipAddrStr.c_str(), telemetryBroadcastPort, telemetryBroadcastPort, sensorDataBroadcastMessagePort};
+    CUdpBroadcastTenant<NTypes::LoRaBroadcastSensorData> downlinkTelemTenant{"Telemetry Downlink Tenant", ipAddrStr.c_str(), telemetryDownlinkPort, telemetryDownlinkPort, downlinkMessagePort};
     CUdpBroadcastTenant<std::array<uint8_t, 7>> udpAlertTenant{"UDP Alert Tenant", ipAddrStr.c_str(), alertPort, alertPort, alertMessagePort};
     CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{"Data Logger Tenant", "/lfs/sensor_module_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort};
 

--- a/app/backplane/sensor_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/sensor_module/src/c_sensing_tenant.cpp
@@ -11,7 +11,7 @@
 
 LOG_MODULE_REGISTER(CSensingTenant);
 
-CSensingTenant::CSensingTenant(const char* name, CMessagePort<NTypes::SensorData>& dataToBroadcast,
+CSensingTenant::CSensingTenant(const char* name, CMessagePort<NTypes::SensorData>& dataToBroadcast, CMessagePort<NTypes::LoRaBroadcastSensorData>& downlinkDataToBroadcast,
                                CMessagePort<NTypes::SensorData>& dataToLog, CDetectionHandler& handler)
     : CTenant(name), dataToBroadcast(dataToBroadcast), dataToLog(dataToLog), detectionHandler(handler),
       imuAccelerometer(*DEVICE_DT_GET(DT_ALIAS(imu))), imuGyroscope(*DEVICE_DT_GET(DT_ALIAS(imu))),
@@ -90,4 +90,10 @@ void CSensingTenant::Run() {
     // we're gonna sleep then give it new data anywas
     dataToBroadcast.Send(data, K_NO_WAIT);
     dataToLog.Send(data, K_NO_WAIT);
+}
+
+void CSensingTenant::sendDownlinkData(const NTypes::SensorData& data) {
+    NTypes::LoRaBroadcastSensorData dataToBroadcast{
+    };
+
 }

--- a/app/backplane/sensor_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/sensor_module/src/c_sensing_tenant.cpp
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(CSensingTenant);
 
 CSensingTenant::CSensingTenant(const char* name, CMessagePort<NTypes::SensorData>& dataToBroadcast, CMessagePort<NTypes::LoRaBroadcastSensorData>& downlinkDataToBroadcast,
                                CMessagePort<NTypes::SensorData>& dataToLog, CDetectionHandler& handler)
-    : CTenant(name), dataToBroadcast(dataToBroadcast), dataToLog(dataToLog), detectionHandler(handler),
+    : CTenant(name), dataToBroadcast(dataToBroadcast), dataToLog(dataToLog), dataToDownlink(downlinkDataToBroadcast), detectionHandler(handler),
       imuAccelerometer(*DEVICE_DT_GET(DT_ALIAS(imu))), imuGyroscope(*DEVICE_DT_GET(DT_ALIAS(imu))),
       primaryBarometer(*DEVICE_DT_GET(DT_ALIAS(primary_barometer))),
       secondaryBarometer(*DEVICE_DT_GET(DT_ALIAS(secondary_barometer))),
@@ -94,6 +94,22 @@ void CSensingTenant::Run() {
 
 void CSensingTenant::sendDownlinkData(const NTypes::SensorData& data) {
     NTypes::LoRaBroadcastSensorData dataToBroadcast{
+        .Barometer = {
+            .Pressure = static_cast<int16_t>(data.PrimaryBarometer.Pressure),
+            .Temperature = static_cast<int16_t>(data.PrimaryBarometer.Temperature),
+        },
+        .Acceleration = {
+            .X = static_cast<int16_t>(data.Acceleration.X),
+            .Y = static_cast<int16_t>(data.Acceleration.Y),
+            .Z = static_cast<int16_t>(data.Acceleration.Z),
+        },
+        .Gyroscope = {
+            .X = static_cast<int16_t>(data.ImuGyroscope.X),
+            .Y = static_cast<int16_t>(data.ImuGyroscope.Y),
+            .Z = static_cast<int16_t>(data.ImuGyroscope.Z),
+        },
     };
+
+    dataToDownlink.Send(dataToBroadcast, K_NO_WAIT);
 
 }

--- a/app/backplane/sensor_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/sensor_module/src/c_sensing_tenant.cpp
@@ -85,15 +85,19 @@ void CSensingTenant::Run() {
 
     data.Temperature.Temperature = thermometer.GetSensorValueFloat(SENSOR_CHAN_AMBIENT_TEMP);
 
-    detectionHandler.HandleData(uptime, data, sensor_states);
     // If we can't send immediately, drop the packet
     // we're gonna sleep then give it new data anywas
     dataToBroadcast.Send(data, K_NO_WAIT);
-    dataToLog.Send(data, K_NO_WAIT);
+    sendDownlinkData(data);
+
+    detectionHandler.HandleData(uptime, data, sensor_states);
+    if (detectionHandler.FlightOccurring()) {
+        dataToLog.Send(data, K_NO_WAIT);
+    }
 }
 
 void CSensingTenant::sendDownlinkData(const NTypes::SensorData& data) {
-    NTypes::LoRaBroadcastSensorData dataToBroadcast{
+    NTypes::LoRaBroadcastSensorData downlinkData{
         .Barometer = {
             .Pressure = static_cast<int16_t>(data.PrimaryBarometer.Pressure),
             .Temperature = static_cast<int16_t>(data.PrimaryBarometer.Temperature),
@@ -110,6 +114,6 @@ void CSensingTenant::sendDownlinkData(const NTypes::SensorData& data) {
         },
     };
 
-    dataToDownlink.Send(dataToBroadcast, K_NO_WAIT);
+    dataToDownlink.Send(downlinkData, K_NO_WAIT);
 
 }

--- a/app/backplane/sensor_module/src/c_sensor_module.cpp
+++ b/app/backplane/sensor_module/src/c_sensor_module.cpp
@@ -10,6 +10,9 @@ LOG_MODULE_REGISTER(sensor_module);
 K_MSGQ_DEFINE(broadcastQueue, sizeof(NTypes::SensorData), 10, 4);
 static auto broadcastMsgQueue = CMsgqMessagePort<NTypes::SensorData>(broadcastQueue);
 
+K_MSGQ_DEFINE(downlinkQueue, sizeof(NTypes::LoRaBroadcastSensorData), 10, 4);
+static auto downlinkMsgQueue = CMsgqMessagePort<NTypes::LoRaBroadcastSensorData>(downlinkQueue);
+
 K_MSGQ_DEFINE(dataLogQueue, sizeof(NTypes::SensorData), 10, 4);
 static auto dataLogMsgQueue = CMsgqMessagePort<NTypes::SensorData>(dataLogQueue);
 
@@ -17,7 +20,7 @@ K_MSGQ_DEFINE(alertQueue, sizeof(const char *), 10, 4);
 static auto alertMsgQueue = CMsgqMessagePort<std::array<uint8_t, 7>>(alertQueue);
 
 CSensorModule::CSensorModule()
-    : CProjectConfiguration(), sensorDataBroadcastMessagePort(broadcastMsgQueue),
+    : CProjectConfiguration(), sensorDataBroadcastMessagePort(broadcastMsgQueue), downlinkMessagePort(downlinkMsgQueue),
       sensorDataLogMessagePort(dataLogMsgQueue), alertMessagePort(alertMsgQueue), flight_log{generateFlightLogPath()} {}
 
 std::string CSensorModule::generateFlightLogPath() {

--- a/data/autocoder_inputs/network_defs.yaml
+++ b/data/autocoder_inputs/network_defs.yaml
@@ -9,6 +9,8 @@ modules:
     port_offsets:
       ina_data:
         port_number: 15
+      downlink_data:
+        port_number: 20
       adc_data:
         port_number: 50
 
@@ -31,6 +33,8 @@ modules:
     id: 3
     base_port: 13000
     port_offsets:
+      downlink_data:
+        port_number: 20
       telemetry:
         port_number: 100
 

--- a/data/autocoder_inputs/types.yaml
+++ b/data/autocoder_inputs/types.yaml
@@ -58,6 +58,66 @@ TemperatureData:
       type: float
   timestamp: false
 
+FixedPointAccelerometerData:
+  description: Accelerometer telemetry data (fixed point).
+  fields:
+    - name: X
+      type: int16_t
+    - name: Y
+      type: int16_t
+    - name: Z
+      type: int16_t
+  timestamp: false
+
+FixedPointBarometerData:
+  description: Barometer telemetry data (fixed point).
+  fields:
+    - name: Pressure
+      type: int16_t
+    - name: Temperature
+      type: int16_t
+  timestamp: false
+
+FixedPointGyroscopeData:
+  description: Gyroscope telemetry data (fixed point).
+  fields:
+    - name: X
+      type: int16_t
+    - name: Y
+      type: int16_t
+    - name: Z
+      type: int16_t
+  timestamp: false
+
+FixedPointMagnetometerData:
+  description: Magnetometer telemetry data (fixed point).
+  fields:
+    - name: X
+      type: int16_t
+    - name: Y
+      type: int16_t
+    - name: Z
+      type: int16_t
+  timestamp: false
+
+FixedPointShuntData:
+  description: Shunt telemetry data (fixed point).
+  fields:
+    - name: Voltage
+      type: int16_t
+    - name: Current
+      type: int16_t
+    - name: Power
+      type: int16_t
+  timestamp: false
+
+FixedPointTemperatureData:
+  description: Single temperature reading (fixed point).
+  fields:
+    - name: Temperature
+      type: uint8_t # Highly unlikely chance of being in sub-zero temperatures
+  timestamp: false
+
 GnssCoordinates:
   description: GNSS coordinate data.
   fields:


### PR DESCRIPTION
- **Start with 16 bit fixed point data types**
- **LoRaBroascastSensorData would give us 22 bytes and would be a huge win**
- **PowerMod LoRa broadcast data**
- **Add downlink data port**
- **Fix type**
- **SensorMod lora packet dropped to 16 bytes**
- **Power mod initialize downlink message queue**
- **Rename some vars in sensor mod changes. Make sure we dont log data all the time in sensor mod. Send downlink data in both**

This closes #<Insert Issue Number Here>

# Description
Write a summary of what you changed. It is helpful to have context on why you made this change! 

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Describe how you tested this change and any special setup configurations in case someone else wants to reproduce this.  

**Test Configuration**:

# Checklist:

- [ ] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [ ] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [ ] The CI checks are passing
- [ ] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [ ] I feel comfortable about this code flying in a rocket

