### PR TITLE
SPI Flash DMA Support and SPI Frequency Improvements

### DIFF
--- a/boards/arm/control_freak/control_freak.dts
+++ b/boards/arm/control_freak/control_freak.dts
@@ -314,7 +314,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 
-		spi-max-frequency = <DT_FREQ_M(42)>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		size = <DT_SIZE_M(128)>;
 		jedec-id = [ef 40 18];
 

--- a/boards/arm/control_freak/control_freak.dts
+++ b/boards/arm/control_freak/control_freak.dts
@@ -314,7 +314,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 
-		spi-max-frequency = <(10 * 1000 * 1000)>;
+		spi-max-frequency = <DT_FREQ_M(42)>;
 		size = <DT_SIZE_M(128)>;
 		jedec-id = [ef 40 18];
 

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -151,7 +151,7 @@
     w5500: w5500@0 {
         compatible = "wiznet,w5500";
         reg = <0x0>;
-        spi-max-frequency = <10000000>;
+        spi-max-frequency = <DT_FREQ_M(42)>;
         int-gpios = <&gpioa 9 GPIO_ACTIVE_LOW>;
         reset-gpios = <&gpioa 10 GPIO_ACTIVE_LOW>;
     };
@@ -167,7 +167,7 @@
         compatible = "jedec,spi-nor";
         reg = <0>;
 
-        spi-max-frequency = <(10 * 1000 * 1000)>;
+        spi-max-frequency = <DT_FREQ_M(42)>;
         size = <DT_SIZE_M(128)>;
         jedec-id = [ef 40 18];
 

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -171,8 +171,16 @@
 	// dma stream
 	// dma channel
 	// config flags
-    dmas = <&dma2 5 3 0x28440 0x03>,
-	       <&dma2 2 3 0x28480 0x03>;
+    dmas = <&dma2 5 3
+            (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH | STM32_DMA_OFFSET_FIXED_4 |
+            STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_8BITS)
+            0x3
+           >,
+	   <&dma2 2 3
+            (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH | STM32_DMA_OFFSET_FIXED_4 |
+            STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_8BITS)
+            0x3
+       >;
 	dma-names = "tx", "rx";
 
     w25q128: w25q128jv@0 {

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -157,11 +157,19 @@
     };
 };
 
+&dma2 {
+	status = "okay";
+};
+
 &spi2 {
     pinctrl-0 = <&spi2_sck_pb10 &spi2_miso_pc2 &spi2_mosi_pc1>;
     cs-gpios = <&gpioc 11 GPIO_ACTIVE_LOW>;
     pinctrl-names = "default";
     status = "okay";
+
+    dmas = <&dma2 5 3 0x28440 0x03>,
+	       <&dma2 2 3 0x28480 0x03>;
+	dma-names = "tx", "rx";
 
     w25q128: w25q128jv@0 {
         compatible = "jedec,spi-nor";

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -151,7 +151,7 @@
     w5500: w5500@0 {
         compatible = "wiznet,w5500";
         reg = <0x0>;
-        spi-max-frequency = <DT_FREQ_M(42)>;
+        spi-max-frequency = <DT_FREQ_M(80)>;
         int-gpios = <&gpioa 9 GPIO_ACTIVE_LOW>;
         reset-gpios = <&gpioa 10 GPIO_ACTIVE_LOW>;
     };
@@ -175,7 +175,7 @@
         compatible = "jedec,spi-nor";
         reg = <0>;
 
-        spi-max-frequency = <DT_FREQ_M(42)>;
+        spi-max-frequency = <DT_FREQ_M(104)>;
         size = <DT_SIZE_M(128)>;
         jedec-id = [ef 40 18];
 

--- a/boards/arm/power_module/power_module.dts
+++ b/boards/arm/power_module/power_module.dts
@@ -167,6 +167,10 @@
     pinctrl-names = "default";
     status = "okay";
 
+    // dma identifier
+	// dma stream
+	// dma channel
+	// config flags
     dmas = <&dma2 5 3 0x28440 0x03>,
 	       <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";

--- a/boards/arm/radio_module/radio_module.dts
+++ b/boards/arm/radio_module/radio_module.dts
@@ -177,6 +177,10 @@
     pinctrl-names = "default";
     status = "okay";
 
+    // dma identifier
+	// dma stream
+	// dma channel
+	// config flags
     dmas = <&dma2 5 3 0x28440 0x03>,
 	   <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";

--- a/boards/arm/radio_module/radio_module.dts
+++ b/boards/arm/radio_module/radio_module.dts
@@ -55,7 +55,7 @@
             label = "User LED2";
         };
     };
-    
+
     connector: gpios {
         compatible = "gpio-leds";
 
@@ -181,8 +181,16 @@
 	// dma stream
 	// dma channel
 	// config flags
-    dmas = <&dma2 5 3 0x28440 0x03>,
-	   <&dma2 2 3 0x28480 0x03>;
+    dmas = <&dma2 5 3
+            (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH | STM32_DMA_OFFSET_FIXED_4 |
+            STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_8BITS)
+            0x3
+           >,
+	   <&dma2 2 3
+            (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH | STM32_DMA_OFFSET_FIXED_4 |
+            STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_8BITS)
+            0x3
+       >;
 	dma-names = "tx", "rx";
 
     lora0: lora0@0 {

--- a/boards/arm/radio_module/radio_module.dts
+++ b/boards/arm/radio_module/radio_module.dts
@@ -158,7 +158,7 @@
     w5500: w5500@0 {
         compatible = "wiznet,w5500";
         reg = <0x0>;
-        spi-max-frequency = <10000000>;
+        spi-max-frequency = <DT_FREQ_M(42)>;
         int-gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
         reset-gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
         local-mac-address = [00 01 02 03 04 05];
@@ -184,7 +184,7 @@
                     <&gpioa 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
                     <&gpioa 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
         power-amplifier-output = "pa-boost";
-        spi-max-frequency = <125000>;
+        spi-max-frequency = <DT_FREQ_M(10)>;
         status = "okay";
     };
 
@@ -192,7 +192,7 @@
         compatible = "jedec,spi-nor";
         reg = <1>;
 
-        spi-max-frequency = <(10 * 1000 * 1000)>;
+        spi-max-frequency = <DT_FREQ_M(42)>;
         size = <DT_SIZE_M(128)>;
         jedec-id = [ef 40 18];
 

--- a/boards/arm/radio_module/radio_module.dts
+++ b/boards/arm/radio_module/radio_module.dts
@@ -165,6 +165,10 @@
     };
 };
 
+&dma2 {
+	status = "okay";
+};
+
 &spi2 {
     pinctrl-0 = <&spi2_sck_pb13 &spi2_miso_pb14 &spi2_mosi_pb15>;
     cs-gpios = <&gpioa 8 GPIO_ACTIVE_LOW
@@ -172,6 +176,10 @@
                >;
     pinctrl-names = "default";
     status = "okay";
+
+    dmas = <&dma2 5 3 0x28440 0x03>,
+	   <&dma2 2 3 0x28480 0x03>;
+	dma-names = "tx", "rx";
 
     lora0: lora0@0 {
         compatible = "semtech,sx1276";

--- a/boards/arm/radio_module/radio_module.dts
+++ b/boards/arm/radio_module/radio_module.dts
@@ -158,7 +158,7 @@
     w5500: w5500@0 {
         compatible = "wiznet,w5500";
         reg = <0x0>;
-        spi-max-frequency = <DT_FREQ_M(42)>;
+        spi-max-frequency = <DT_FREQ_M(80)>;
         int-gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
         reset-gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
         local-mac-address = [00 01 02 03 04 05];
@@ -200,7 +200,7 @@
         compatible = "jedec,spi-nor";
         reg = <1>;
 
-        spi-max-frequency = <DT_FREQ_M(42)>;
+        spi-max-frequency = <DT_FREQ_M(104)>;
         size = <DT_SIZE_M(128)>;
         jedec-id = [ef 40 18];
 

--- a/boards/arm/sensor_module/sensor_module.dts
+++ b/boards/arm/sensor_module/sensor_module.dts
@@ -111,6 +111,10 @@
 	status = "okay";
 };
 
+&dma2 {
+	status = "okay";
+};
+
 &spi1 {
 	pinctrl-0 = <&spi1_sck_pa5
 				 &spi1_miso_pa6 &spi1_mosi_pa7>;
@@ -118,6 +122,11 @@
 
 	pinctrl-names = "default";
 	status = "okay";
+
+	dmas = <&dma2 5 3 0x28440 0x03>,
+	   <&dma2 2 3 0x28480 0x03>;
+	dma-names = "tx", "rx";
+
 
 	w5500: w5500@0 {
 		compatible = "wiznet,w5500";

--- a/boards/arm/sensor_module/sensor_module.dts
+++ b/boards/arm/sensor_module/sensor_module.dts
@@ -122,7 +122,7 @@
 	w5500: w5500@0 {
 		compatible = "wiznet,w5500";
 		reg = <0x0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <DT_FREQ_M(42)>;
 		int-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpioa 3 GPIO_ACTIVE_LOW>;
 		zephyr,random-mac-address;
@@ -140,7 +140,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 
-		spi-max-frequency = <(10 * 1000 * 1000)>;
+		spi-max-frequency = <DT_FREQ_M(42)>;
 		size = <DT_SIZE_M(512)>;
 		jedec-id = [ef 40 20];
 

--- a/boards/arm/sensor_module/sensor_module.dts
+++ b/boards/arm/sensor_module/sensor_module.dts
@@ -127,8 +127,16 @@
 	// dma stream
 	// dma channel
 	// config flags
-	dmas = <&dma2 5 3 0x28440 0x03>,
-	   <&dma2 2 3 0x28480 0x03>;
+    dmas = <&dma2 5 3
+            (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH | STM32_DMA_OFFSET_FIXED_4 |
+            STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_8BITS)
+            0x3
+           >,
+	   <&dma2 2 3
+            (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH | STM32_DMA_OFFSET_FIXED_4 |
+            STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_8BITS)
+            0x3
+       >;
 	dma-names = "tx", "rx";
 
 

--- a/boards/arm/sensor_module/sensor_module.dts
+++ b/boards/arm/sensor_module/sensor_module.dts
@@ -123,6 +123,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 
+	// dma identifier
+	// dma stream
+	// dma channel
+	// config flags
 	dmas = <&dma2 5 3 0x28440 0x03>,
 	   <&dma2 2 3 0x28480 0x03>;
 	dma-names = "tx", "rx";

--- a/boards/arm/sensor_module/sensor_module.dts
+++ b/boards/arm/sensor_module/sensor_module.dts
@@ -131,7 +131,7 @@
 	w5500: w5500@0 {
 		compatible = "wiznet,w5500";
 		reg = <0x0>;
-		spi-max-frequency = <DT_FREQ_M(42)>;
+		spi-max-frequency = <DT_FREQ_M(80)>;
 		int-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpioa 3 GPIO_ACTIVE_LOW>;
 		zephyr,random-mac-address;
@@ -149,7 +149,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 
-		spi-max-frequency = <DT_FREQ_M(42)>;
+		spi-max-frequency = <DT_FREQ_M(104)>;
 		size = <DT_SIZE_M(512)>;
 		jedec-id = [ef 40 20];
 


### PR DESCRIPTION
# Description
Increase the SPI flash frequencies from 10 MHz to the max rating based on datasheets. Also use the devicetree convention DT_FREQ_X(), instead of super long numbers or random multiplications for readability. Note that the frequencies may not actually run to this speed, especially if the CPU clock speed is lower. I.E a microcontroller running at 48 MHz will not generate a 80 MHz SPI signal. This is just defining the upper limit in general.

Also, add DMA for writing to flash and trying to get as much performance as we can when writing to the filesystem

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Compiling and running this on different boards. Confirming Ethernet is still sending and flash can still be accessed

# Checklist:
- [x] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [x] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [x] The CI checks are passing
- [x] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [x] I feel comfortable about this code flying in a rocket

