### PR TITLE
Data Logger Tenant Syncs With Filesystem

### DIFF
--- a/app/backplane/power_module/include/c_power_module.h
+++ b/app/backplane/power_module/include/c_power_module.h
@@ -69,7 +69,7 @@ private:
         "Broadcast Tenant", ipAddrStr, downlinkBroadcastPort, downlinkBroadcastPort, sensorDataDownlinkMessagePort
     };
     CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{
-        "Data Logger Tenant", "/lfs/sensor_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort
+        "Data Logger Tenant", "/lfs/sensor_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort, K_SECONDS(60), 5
     };
     CUdpAlertTenant alertTenant{"Alert Tenant", ipAddrStr, NNetworkDefs::ALERT_PORT};
 

--- a/app/backplane/radio_module/include/c_radio_module.h
+++ b/app/backplane/radio_module/include/c_radio_module.h
@@ -75,7 +75,7 @@ private:
     CLoraTransmitTenant loraTransmitTenant{"LoRa Transmit Tenant", lora, &loraBroadcastMessagePort};
     CLoraReceiveTenant loraReceiveTenant{"LoRa Receive Tenant", loraTransmitTenant, ipAddrStr, radioModuleSourcePort};
 #endif
-    CDataLoggerTenant<NTypes::GnssData> dataLoggerTenant{"Data Logger Tenant", "/lfs/gps_data.bin", LogMode::Growing, 0, gnssDataLogMessagePort};
+    CDataLoggerTenant<NTypes::GnssData> dataLoggerTenant{"Data Logger Tenant", "/lfs/gps_data.bin", LogMode::Growing, 0, gnssDataLogMessagePort, K_SECONDS(15), 5};
     CStateMachineUpdater stateMachineUpdater;
 
     // Tasks

--- a/app/backplane/sensor_module/include/c_sensor_module.h
+++ b/app/backplane/sensor_module/include/c_sensor_module.h
@@ -72,7 +72,7 @@ class CSensorModule : public CProjectConfiguration {
     CUdpBroadcastTenant<NTypes::SensorData> broadcastTenant{"Broadcast Tenant", ipAddrStr.c_str(), telemetryBroadcastPort, telemetryBroadcastPort, sensorDataBroadcastMessagePort};
     CUdpBroadcastTenant<NTypes::LoRaBroadcastSensorData> downlinkTelemTenant{"Telemetry Downlink Tenant", ipAddrStr.c_str(), telemetryDownlinkPort, telemetryDownlinkPort, downlinkMessagePort};
     CUdpBroadcastTenant<std::array<uint8_t, 7>> udpAlertTenant{"UDP Alert Tenant", ipAddrStr.c_str(), alertPort, alertPort, alertMessagePort};
-    CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{"Data Logger Tenant", "/lfs/sensor_module_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort};
+    CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{"Data Logger Tenant", "/lfs/sensor_module_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort, K_SECONDS(3), 0};
 
     // Tasks
     CTask networkTask{"Networking Task", 15, 3072, 5};

--- a/include/f_core/os/c_datalogger.h
+++ b/include/f_core/os/c_datalogger.h
@@ -14,6 +14,7 @@ class datalogger {
     datalogger(const char *filename, LogMode mode, std::size_t num_packets);
     int write(const void *data, std::size_t size);
     int close();
+    int sync();
 
     const char *filename;
     fs_file_t file;
@@ -57,7 +58,7 @@ class CDataLogger {
      * Write a packet to the file
      * @param packet the data to write to the file
      */
-    int write(const PacketType &packet) {
+    int Write(const PacketType &packet) {
         return internal.write(reinterpret_cast<const void *>(&packet), sizeof(PacketType));
     }
     /**
@@ -67,7 +68,9 @@ class CDataLogger {
      * @retval -ENOTSUP when not implemented by underlying file system driver;
      * @retval <0 a negative errno code on error.
      */
-    int close() { return internal.close(); }
+    int Close() { return internal.close(); }
+
+    int Sync() { return internal.sync(); }
 
   private:
     detail::datalogger internal;

--- a/include/f_core/os/tenants/c_datalogger_tenant.h
+++ b/include/f_core/os/tenants/c_datalogger_tenant.h
@@ -6,19 +6,37 @@
 #include <f_core/os/c_datalogger.h>
 #include <zephyr/logging/log.h>
 
+
+
 template <typename T>
 class CDataLoggerTenant : public CTenant {
 public:
-    CDataLoggerTenant(const char *name, const char *filename, LogMode mode, std::size_t num_packets, CMessagePort<T> &messagePort)
-        : CTenant(name), messagePort(messagePort), dataLogger(filename, mode, num_packets), filename(filename) {}
+    CDataLoggerTenant(const char *name, const char *filename, LogMode mode, std::size_t numPackets, CMessagePort<T> &messagePort, k_timeout_t syncTimeout = K_FOREVER, int syncOnCount = 0)
+        : CTenant(name), messagePort(messagePort), dataLogger(filename, mode, numPackets), filename(filename), syncTimeout(syncTimeout), syncOnCount(syncOnCount) {}
 
     ~CDataLoggerTenant() override {
         Cleanup();
     }
 
+    void Startup() override {
+        if (syncTimeout.ticks != K_FOREVER.ticks) {
+            syncTimer.StartTimer(syncTimeout);
+        }
+    }
+
     void Run() override {
         if (T message{}; messagePort.Receive(message, K_FOREVER) == 0) {
             dataLogger.write(message);
+            syncCounter++;
+
+            if (syncTimer.IsRunning() && syncTimer.IsExpired()) {
+                dataLogger.sync();
+            }
+
+            if (syncCounter >= syncOnCount) {
+                dataLogger.sync();
+                syncCounter = 0;
+            }
         }
     }
 
@@ -30,6 +48,14 @@ private:
     CMessagePort<T> &messagePort;
     CDataLogger<T> dataLogger;
     const char *filename;
+
+    // FS Sync after every X time
+    CSoftTimer syncTimer;
+    k_timeout_t syncTimeout = K_FOREVER;
+
+    // FS Sync on every N messages
+    int syncCounter = 0;
+    int syncOnCount;
 };
 
 #endif //C_DATALOGGER_TENANT_H

--- a/include/f_core/os/tenants/c_datalogger_tenant.h
+++ b/include/f_core/os/tenants/c_datalogger_tenant.h
@@ -26,22 +26,22 @@ public:
 
     void Run() override {
         if (T message{}; messagePort.Receive(message, K_FOREVER) == 0) {
-            dataLogger.write(message);
+            dataLogger.Write(message);
             syncCounter++;
 
             if (syncTimer.IsRunning() && syncTimer.IsExpired()) {
-                dataLogger.sync();
+                dataLogger.Sync();
             }
 
             if (syncCounter >= syncOnCount) {
-                dataLogger.sync();
+                dataLogger.Sync();
                 syncCounter = 0;
             }
         }
     }
 
     void Cleanup() override {
-        dataLogger.close();
+        dataLogger.Close();
     }
 
 private:

--- a/include/f_core/utils/c_soft_timer.h
+++ b/include/f_core/utils/c_soft_timer.h
@@ -44,6 +44,18 @@ public:
 
     /**
     * Start the timer with the given expiration time
+    * @param timeout Zephyr timeout object
+    * @param initialExpiration Zephyr timeout object for the initial expiration time
+    */
+    void StartTimer(k_timeout_t timeout, k_timeout_t initialExpiration) {
+        // Duration (second arg) is the initial expiration time
+        // Period (third arg) is the time set after each expiration
+        k_timer_start(&timer, timeout, initialExpiration);
+        running = true;
+    }
+
+    /**
+    * Start the timer with the given expiration time
     * @param millis Time in milliseconds until the timer expires
     * @param initialExpirationMillis Time in milliseconds to wait before the first expiration
     */
@@ -113,7 +125,7 @@ public:
      * Get the user data for the timer
      * @return User data
      */
-    void *GetUserData() const {
+    void* GetUserData() const {
         return k_timer_user_data_get(&timer);
     }
 
@@ -129,7 +141,6 @@ private:
     k_timer timer;
     bool running = false;
 };
-
 
 
 #endif //C_SOFT_TIMER_H

--- a/include/f_core/utils/c_soft_timer.h
+++ b/include/f_core/utils/c_soft_timer.h
@@ -32,6 +32,17 @@ public:
     }
 
     /**
+     * Start the timer with the given expiration time
+     * @param timeout Zephyr timeout object
+     */
+    void StartTimer(k_timeout_t timeout) {
+        // Duration (second arg) is the initial expiration time
+        // Period (third arg) is the time set after each expiration
+        k_timer_start(&timer, timeout, timeout);
+        running = true;
+    }
+
+    /**
     * Start the timer with the given expiration time
     * @param millis Time in milliseconds until the timer expires
     * @param initialExpirationMillis Time in milliseconds to wait before the first expiration

--- a/lib/f_core/os/c_datalogger.cpp
+++ b/lib/f_core/os/c_datalogger.cpp
@@ -46,8 +46,16 @@ int datalogger::write(const void *data, std::size_t size) {
     LOG_ERR("Invalid LogMode: %d", (int) mode);
     return -EINVAL;
 }
+
 int datalogger::close() {
     LOG_DBG("Closing %s", filename);
     return fs_close(&file);
 }
+
+int datalogger::sync() {
+    LOG_DBG("Syncing %s", filename);
+    return fs_sync(&file);
+}
+
+
 } // namespace detail


### PR DESCRIPTION
# Description
The Datalogger implementation never calls sync and expects files to close for it to be written to flash. Add a new sync call to be able to write to flash while the file is still open in the fs.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Ran new code on power module and confirmed that it wrote to flash when a certain amount of time was reached or certain amount of data was received

# Checklist:

- [ ] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [ ] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [ ] The CI checks are passing
- [ ] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [ ] I feel comfortable about this code flying in a rocket

