### PR TITLE
Timestamps in Power and Sensor Module Telemetry Logging

### DIFF
--- a/app/backplane/power_module/include/c_power_module.h
+++ b/app/backplane/power_module/include/c_power_module.h
@@ -55,7 +55,7 @@ private:
 
     // Message Ports
     CMessagePort<NTypes::SensorData>& sensorDataBroadcastMessagePort;
-    CMessagePort<NTypes::SensorData>& sensorDataLogMessagePort;
+    CMessagePort<NTypes::TimestampedSensorData>& sensorDataLogMessagePort;
     CMessagePort<NTypes::LoRaBroadcastSensorData>& sensorDataDownlinkMessagePort;
 
     // Tenants
@@ -68,7 +68,7 @@ private:
     CUdpBroadcastTenant<NTypes::LoRaBroadcastSensorData> downlinkBroadcastTenant{
         "Broadcast Tenant", ipAddrStr, downlinkBroadcastPort, downlinkBroadcastPort, sensorDataDownlinkMessagePort
     };
-    CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{
+    CDataLoggerTenant<NTypes::TimestampedSensorData> dataLoggerTenant{
         "Data Logger Tenant", "/lfs/sensor_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort
     };
     CUdpAlertTenant alertTenant{"Alert Tenant", ipAddrStr, NNetworkDefs::ALERT_PORT};

--- a/app/backplane/power_module/include/c_sensing_tenant.h
+++ b/app/backplane/power_module/include/c_sensing_tenant.h
@@ -1,6 +1,8 @@
 #ifndef C_SENSING_TENANT_H
 #define C_SENSING_TENANT_H
 
+#include "f_core/device/c_rtc.h"
+
 #include <n_autocoder_types.h>
 
 #include <f_core/messaging/c_message_port.h>
@@ -10,7 +12,7 @@
 
 class CSensingTenant : public CTenant, public CObserver {
 public:
-    explicit CSensingTenant(const char* name, CMessagePort<NTypes::SensorData> &dataToBroadcast, CMessagePort<NTypes::SensorData> &dataToLog, CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink)
+    explicit CSensingTenant(const char* name, CMessagePort<NTypes::SensorData> &dataToBroadcast, CMessagePort<NTypes::TimestampedSensorData> &dataToLog, CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink)
         : CTenant(name), dataToBroadcast(dataToBroadcast), dataToLog(dataToLog), dataToDownlink(dataToDownlink) {}
 
     ~CSensingTenant() override = default;
@@ -25,9 +27,10 @@ public:
 
 private:
     CMessagePort<NTypes::SensorData> &dataToBroadcast;
-    CMessagePort<NTypes::SensorData> &dataToLog;
+    CMessagePort<NTypes::TimestampedSensorData> &dataToLog;
     CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink;
     CSoftTimer timer{nullptr, nullptr};
+    CRtc rtc{*DEVICE_DT_GET(DT_ALIAS(rtc))};
 
     void sendDownlinkData(const NTypes::SensorData &data);
 };

--- a/app/backplane/power_module/src/c_power_module.cpp
+++ b/app/backplane/power_module/src/c_power_module.cpp
@@ -10,8 +10,8 @@
 K_MSGQ_DEFINE(broadcastQueue, sizeof(NTypes::SensorData), 10, 4);
 static auto broadcastMsgQueue = CMsgqMessagePort<NTypes::SensorData>(broadcastQueue);
 
-K_MSGQ_DEFINE(dataLogQueue, sizeof(NTypes::SensorData), 10, 4);
-static auto dataLogMsgQueue = CMsgqMessagePort<NTypes::SensorData>(dataLogQueue);
+K_MSGQ_DEFINE(dataLogQueue, sizeof(NTypes::TimestampedSensorData), 10, 4);
+static auto dataLogMsgQueue = CMsgqMessagePort<NTypes::TimestampedSensorData>(dataLogQueue);
 
 K_MSGQ_DEFINE(downlinkQueue, sizeof(NTypes::LoRaBroadcastSensorData), 10, 4);
 static auto downlinkMessageQueue = CMsgqMessagePort<NTypes::LoRaBroadcastSensorData>(downlinkQueue);

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -53,7 +53,7 @@ void CSensingTenant::Run() {
         }
         i++;
     }
-    
+
     uint32_t tmpTimestamp = 0;
     int ret = rtc.GetUnixTime(tmpTimestamp);
     if (ret < 0) {

--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -55,8 +55,7 @@ void CSensingTenant::Run() {
     }
 
     uint32_t tmpTimestamp = 0;
-    int ret = rtc.GetUnixTime(tmpTimestamp);
-    if (ret < 0) {
+    if (int ret = rtc.GetUnixTime(tmpTimestamp); ret < 0) {
         LOG_ERR("Failed to get time from RTC");
     } else {
         timestampedData.timestamp = tmpTimestamp;

--- a/app/backplane/sensor_module/include/c_sensing_tenant.h
+++ b/app/backplane/sensor_module/include/c_sensing_tenant.h
@@ -2,6 +2,7 @@
 #define C_SENSING_TENANT_H
 
 #include "c_detection_handler.h"
+#include "f_core/device/c_rtc.h"
 
 #include <array>
 #include <f_core/device/sensor/c_accelerometer.h>
@@ -42,6 +43,9 @@ class CSensingTenant : public CTenant {
     CMagnetometer magnetometer;
 
     std::array<CSensorDevice *, 7> sensors;
+
+
+    CRtc rtc{*DEVICE_DT_GET(DT_ALIAS(rtc))};
 
     void sendDownlinkData(const NTypes::SensorData &data);
 };

--- a/app/backplane/sensor_module/include/c_sensing_tenant.h
+++ b/app/backplane/sensor_module/include/c_sensing_tenant.h
@@ -19,7 +19,7 @@ class CSensorDevice;
 class CSensingTenant : public CTenant {
   public:
     explicit CSensingTenant(const char *name, CMessagePort<NTypes::SensorData> &dataToBroadcast, CMessagePort<NTypes::LoRaBroadcastSensorData> &downlinkDataToBroadcast,
-                            CMessagePort<NTypes::SensorData> &dataToLog, CDetectionHandler &handler);
+                            CMessagePort<NTypes::TimestampedSensorData> &dataToLog, CDetectionHandler &handler);
     ~CSensingTenant() override = default;
 
     void Startup() override;
@@ -28,7 +28,7 @@ class CSensingTenant : public CTenant {
 
   private:
     CMessagePort<NTypes::SensorData> &dataToBroadcast;
-    CMessagePort<NTypes::SensorData> &dataToLog;
+    CMessagePort<NTypes::TimestampedSensorData> &dataToLog;
     CMessagePort<NTypes::LoRaBroadcastSensorData> &dataToDownlink;
 
     CDetectionHandler &detectionHandler;

--- a/app/backplane/sensor_module/include/c_sensor_module.h
+++ b/app/backplane/sensor_module/include/c_sensor_module.h
@@ -59,7 +59,7 @@ class CSensorModule : public CProjectConfiguration {
     // Message Ports
     CMessagePort<NTypes::SensorData>& sensorDataBroadcastMessagePort;
     CMessagePort<NTypes::LoRaBroadcastSensorData>& downlinkMessagePort;
-    CMessagePort<NTypes::SensorData>& sensorDataLogMessagePort;
+    CMessagePort<NTypes::TimestampedSensorData>& sensorDataLogMessagePort;
     CMessagePort<std::array<uint8_t, 7>>& alertMessagePort;
 
     CFlightLog flight_log;
@@ -72,7 +72,7 @@ class CSensorModule : public CProjectConfiguration {
     CUdpBroadcastTenant<NTypes::SensorData> broadcastTenant{"Broadcast Tenant", ipAddrStr.c_str(), telemetryBroadcastPort, telemetryBroadcastPort, sensorDataBroadcastMessagePort};
     CUdpBroadcastTenant<NTypes::LoRaBroadcastSensorData> downlinkTelemTenant{"Telemetry Downlink Tenant", ipAddrStr.c_str(), telemetryDownlinkPort, telemetryDownlinkPort, downlinkMessagePort};
     CUdpBroadcastTenant<std::array<uint8_t, 7>> udpAlertTenant{"UDP Alert Tenant", ipAddrStr.c_str(), alertPort, alertPort, alertMessagePort};
-    CDataLoggerTenant<NTypes::SensorData> dataLoggerTenant{"Data Logger Tenant", "/lfs/sensor_module_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort};
+    CDataLoggerTenant<NTypes::TimestampedSensorData> dataLoggerTenant{"Data Logger Tenant", "/lfs/sensor_module_data.bin", LogMode::Growing, 0, sensorDataLogMessagePort};
 
     // Tasks
     CTask networkTask{"Networking Task", 15, 3072, 5};

--- a/app/backplane/sensor_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/sensor_module/src/c_sensing_tenant.cpp
@@ -62,6 +62,13 @@ void CSensingTenant::Run() {
 #ifndef CONFIG_ARCH_POSIX
     magnetometer.UpdateSensorValue();
 #endif
+    uint32_t tmpTimestamp = 0;
+    if (int ret = rtc.GetUnixTime(tmpTimestamp); ret < 0) {
+        LOG_ERR("Failed to get time from RTC");
+    } else {
+        timestampedData.timestamp = tmpTimestamp;
+    }
+
     data.Acceleration.X = accelerometer.GetSensorValueFloat(SENSOR_CHAN_ACCEL_X);
     data.Acceleration.Y = accelerometer.GetSensorValueFloat(SENSOR_CHAN_ACCEL_Y);
     data.Acceleration.Z = accelerometer.GetSensorValueFloat(SENSOR_CHAN_ACCEL_Z);

--- a/app/backplane/sensor_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/sensor_module/src/c_sensing_tenant.cpp
@@ -12,7 +12,7 @@
 LOG_MODULE_REGISTER(CSensingTenant);
 
 CSensingTenant::CSensingTenant(const char* name, CMessagePort<NTypes::SensorData>& dataToBroadcast, CMessagePort<NTypes::LoRaBroadcastSensorData>& downlinkDataToBroadcast,
-                               CMessagePort<NTypes::SensorData>& dataToLog, CDetectionHandler& handler)
+                               CMessagePort<NTypes::TimestampedSensorData>& dataToLog, CDetectionHandler& handler)
     : CTenant(name), dataToBroadcast(dataToBroadcast), dataToLog(dataToLog), dataToDownlink(downlinkDataToBroadcast), detectionHandler(handler),
       imuAccelerometer(*DEVICE_DT_GET(DT_ALIAS(imu))), imuGyroscope(*DEVICE_DT_GET(DT_ALIAS(imu))),
       primaryBarometer(*DEVICE_DT_GET(DT_ALIAS(primary_barometer))),
@@ -47,7 +47,8 @@ void CSensingTenant::Run() {
     if (!detectionHandler.ContinueCollecting()) {
         return;
     }
-    NTypes::SensorData data{};
+    NTypes::TimestampedSensorData timestampedData{0};
+    NTypes::SensorData &data = timestampedData.data;
 
     uint64_t uptime = k_uptime_get();
 
@@ -92,7 +93,7 @@ void CSensingTenant::Run() {
 
     detectionHandler.HandleData(uptime, data, sensor_states);
     if (detectionHandler.FlightOccurring()) {
-        dataToLog.Send(data, K_NO_WAIT);
+        dataToLog.Send(timestampedData, K_NO_WAIT);
     }
 }
 

--- a/app/backplane/sensor_module/src/c_sensor_module.cpp
+++ b/app/backplane/sensor_module/src/c_sensor_module.cpp
@@ -13,8 +13,8 @@ static auto broadcastMsgQueue = CMsgqMessagePort<NTypes::SensorData>(broadcastQu
 K_MSGQ_DEFINE(downlinkQueue, sizeof(NTypes::LoRaBroadcastSensorData), 10, 4);
 static auto downlinkMsgQueue = CMsgqMessagePort<NTypes::LoRaBroadcastSensorData>(downlinkQueue);
 
-K_MSGQ_DEFINE(dataLogQueue, sizeof(NTypes::SensorData), 10, 4);
-static auto dataLogMsgQueue = CMsgqMessagePort<NTypes::SensorData>(dataLogQueue);
+K_MSGQ_DEFINE(dataLogQueue, sizeof(NTypes::TimestampedSensorData), 10, 4);
+static auto dataLogMsgQueue = CMsgqMessagePort<NTypes::TimestampedSensorData>(dataLogQueue);
 
 K_MSGQ_DEFINE(alertQueue, sizeof(const char *), 10, 4);
 static auto alertMsgQueue = CMsgqMessagePort<std::array<uint8_t, 7>>(alertQueue);


### PR DESCRIPTION
# Description
Add a timestamp field for when sensor and power mod log a telemetry packet, so we have somewhat of an understanding of time between measurements.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Working compile and during integration testing of the filesystem over the next few weeks

# Checklist:

- [ ] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [ ] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [ ] The CI checks are passing
- [ ] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [ ] I feel comfortable about this code flying in a rocket

