### PR TITLE
Update Downlink Scaling Values

### DIFF
--- a/app/backplane/power_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/power_module/src/c_sensing_tenant.cpp
@@ -96,10 +96,10 @@ void CSensingTenant::Notify(void* ctx) {
 
 void CSensingTenant::sendDownlinkData(const NTypes::SensorData& data) {
     NTypes::LoRaBroadcastSensorData downlinkData{
-        .RailBattery = {.Voltage = static_cast<int16_t>(data.RailBattery.Voltage),
+        .RailBattery = {.Voltage = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.RailBattery.Voltage)),
                         .Current = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.RailBattery.Current)),
                         .Power = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.RailBattery.Power))},
-        .Rail3v3 = {.Voltage = static_cast<int16_t>(data.Rail3v3.Voltage),
+        .Rail3v3 = {.Voltage = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.Rail3v3.Voltage)),
                     .Current = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.Rail3v3.Current)),
                     .Power = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.Rail3v3.Power))}};
 

--- a/app/backplane/sensor_module/src/c_sensing_tenant.cpp
+++ b/app/backplane/sensor_module/src/c_sensing_tenant.cpp
@@ -145,14 +145,16 @@ void CSensingTenant::sendDownlinkData(const NTypes::SensorData& data) {
     NTypes::LoRaBroadcastSensorData downlinkData{
         .Barometer =
             {
-                .Pressure = static_cast<int16_t>(data.PrimaryBarometer.Pressure),
+                // x10: 0.1 kPa resolution, covers 0-3276 kPa (int16_t max)
+                .Pressure = static_cast<int16_t>(data.PrimaryBarometer.Pressure * 10.0f),
                 .Temperature = static_cast<int16_t>(data.PrimaryBarometer.Temperature),
             },
         .Acceleration =
             {
-                .X = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.Acceleration.X)),
-                .Y = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.Acceleration.Y)),
-                .Z = static_cast<int16_t>(CSensorDevice::ToMilliUnits(data.Acceleration.Z)),
+                // x10: 0.1 m/s² resolution, covers ±3276 m/s² (~±334g) — safe for ADXL375 200g range
+                .X = static_cast<int16_t>(data.Acceleration.X * 10.0f),
+                .Y = static_cast<int16_t>(data.Acceleration.Y * 10.0f),
+                .Z = static_cast<int16_t>(data.Acceleration.Z * 10.0f),
             },
         .Gyroscope =
             {

--- a/app/ground/receiver_module/include/c_receiver_module.h
+++ b/app/ground/receiver_module/include/c_receiver_module.h
@@ -66,7 +66,8 @@ class CReceiverModule : public CProjectConfiguration {
     CUdpListenerTenant dataRequestListenerTenant{"Radio Module Data Request Listener Tenant", ipAddrStr.c_str(),
                                                  radioModuleDataRequestPort, &loraBroadcastMessagePort};
 
-    CLoraFrameToUdpHandler loraToUdpHandler{ipAddrStr.c_str(), radioModuleSourcePort};
+    CLoraFrameToUdpHandler loraToUdpHandler{ipAddrStr.c_str(), radioModuleSourcePort,
+                                             NNetworkDefs::RADIO_MODULE_LORA_RX_STATS_PORT};
 
     // Tasks
     CTask networkingTask{"UDP Listener Task", 15, 4096, 0};

--- a/include/f_core/radio/frame_handlers/c_lora_frame_to_udp_handler.h
+++ b/include/f_core/radio/frame_handlers/c_lora_frame_to_udp_handler.h
@@ -7,10 +7,11 @@ class CLoraFrameToUdpHandler : public CLoraFrameHandler {
   public:
     /**
      * @brief Constructor
-     * @param ip IP address instance to bind to
+     * @param ip IP address to bind to
      * @param srcPort Source port to bind to
+     * @param statsPort Port to emit LoRa receive stats (RSSI/SNR) on; 0 disables
      */
-    explicit CLoraFrameToUdpHandler(const char* ip, uint16_t srcPort);
+    explicit CLoraFrameToUdpHandler(const char* ip, uint16_t srcPort, uint16_t statsPort = 0);
 
     /**
      * See parent docs
@@ -19,4 +20,5 @@ class CLoraFrameToUdpHandler : public CLoraFrameHandler {
 
   private:
     CUdpSocket sock;
+    uint16_t statsPort;
 };

--- a/lib/f_core/radio/frame_handlers/c_lora_frame_to_udp_handler.cpp
+++ b/lib/f_core/radio/frame_handlers/c_lora_frame_to_udp_handler.cpp
@@ -2,9 +2,18 @@
 
 #include "f_core/net/network/c_ipv4.h"
 
-CLoraFrameToUdpHandler::CLoraFrameToUdpHandler(const char* ip, uint16_t srcPort) : sock(CIPv4(ip), srcPort, 0) {}
+CLoraFrameToUdpHandler::CLoraFrameToUdpHandler(const char* ip, uint16_t srcPort, uint16_t statsPort)
+    : sock(CIPv4(ip), srcPort, 0), statsPort(statsPort) {}
 
 void CLoraFrameToUdpHandler::HandleFrame(const ReceivedLaunchLoraFrame& rxFrame) {
     const LaunchLoraFrame& frame = rxFrame.Frame;
     sock.TransmitAsynchronous(&frame.Payload, frame.Size, frame.Port);
+
+    if (statsPort != 0) {
+        struct __attribute__((packed)) {
+            int16_t ReceivedSignalStrength;
+            int8_t SignalToNoise;
+        } stats{rxFrame.ReceivedSignalStrength, rxFrame.SignalToNoise};
+        sock.TransmitAsynchronous(&stats, sizeof(stats), statsPort);
+    }
 }


### PR DESCRIPTION
# Description
Correct scaling values for downlinking. Avoids overflows and ensures we get better precision, such as not having 1 voltage increments for power module

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
GSW config showing both the downlinked and original values and comparing the results

# Checklist:

- [x] New functionality is documented in the necessary spots (i.e new functions documented in the header)
- [x] Unit tests cover any new functionality or edge cases that the PR was meant to resolve (if applicable) 
- [x] The CI checks are passing
- [x] I reviewed my own code in the GitHub diff and am sure that each change is intentional
- [x] I feel comfortable about this code flying in a rocket

